### PR TITLE
Allow non-verse headings in between verses

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Requires you to have bible in markdown in your vault, with similar structure to 
   - *exception*: if your file is named "Gen-01", you can type either "Gen-01,1-4" or "Gen 1,1-4" 
 
 ## Wrong verses are linked? Or linking doesn't work and you have files with right format?
-- Go to Plugin settings and try changing "Verse offset" accordingly.
+- Go to Plugin settings and try changing "Verse offset" or "Verse heading level" accordingly.
 
 ## Installing 
 Available through Obsidian Community plugins (Settings/Comumnity plugins) 

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,7 +8,7 @@ export interface PluginSettings {
 	prefix: string;
 	linkEndVerse: boolean;
 	verseOffset: number;
-	verseHeadingLevel: string;
+	verseHeadingLevel?: number;
 	useInvisibleLinks: boolean;
 	newLines: boolean;
 	eachVersePrefix: string;
@@ -25,7 +25,7 @@ const DEFAULT_SETTINGS: Partial<PluginSettings> = {
 	prefix: "",
 	linkEndVerse: false,
 	verseOffset: 0,
-	verseHeadingLevel: "",
+	verseHeadingLevel: undefined,
 	useInvisibleLinks: true,
 	newLines: false,
 	eachVersePrefix: "",

--- a/src/main.ts
+++ b/src/main.ts
@@ -8,6 +8,7 @@ export interface PluginSettings {
 	prefix: string;
 	linkEndVerse: boolean;
 	verseOffset: number;
+	verseHeadingLevel: string;
 	useInvisibleLinks: boolean;
 	newLines: boolean;
 	eachVersePrefix: string;
@@ -24,6 +25,7 @@ const DEFAULT_SETTINGS: Partial<PluginSettings> = {
 	prefix: "",
 	linkEndVerse: false,
 	verseOffset: 0,
+	verseHeadingLevel: "",
 	useInvisibleLinks: true,
 	newLines: false,
 	eachVersePrefix: "",

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -45,15 +45,20 @@ export class SettingsTab extends PluginSettingTab {
 		new Setting(containerEl)
 			.setName("Verse heading level")
 			.setDesc('If set, only headings of specified level are considered verses (if first heading of this level is always a verse, also set "Verse offset" to -1)')
-			.addText((inputBox) =>
-				inputBox
-					.setPlaceholder('e.g. "######"')
-					.setValue(this.plugin.settings.verseHeadingLevel)
-					.onChange(async (value) => {
-						this.plugin.settings.verseHeadingLevel = value;
-						await this.plugin.saveSettings();
-					})
-			)
+			.addDropdown((dropdown) => {
+				dropdown.addOption("any", "any")
+				dropdown.addOption("6", "######")
+				dropdown.addOption("5", "#####")
+				dropdown.addOption("4", "####")
+				dropdown.addOption("3", "###")
+				dropdown.addOption("2", "##")
+				dropdown.addOption("1", "#")
+				dropdown.setValue(this.plugin.settings.verseHeadingLevel?.toString() ?? "any")
+				dropdown.onChange(async (value) => {
+					this.plugin.settings.verseHeadingLevel = value === "any" ? undefined : Number(value);
+					await this.plugin.saveSettings();
+				})
+			})
 
         new Setting(containerEl)
             .setName("Link prefix")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -42,6 +42,19 @@ export class SettingsTab extends PluginSettingTab {
                     })
             )
 
+		new Setting(containerEl)
+			.setName("Verse heading level")
+			.setDesc('If set, only headings of specified level are considered verses (if first heading of this level is always a verse, also set "Verse offset" to -1)')
+			.addText((inputBox) =>
+				inputBox
+					.setPlaceholder('e.g. "######"')
+					.setValue(this.plugin.settings.verseHeadingLevel)
+					.onChange(async (value) => {
+						this.plugin.settings.verseHeadingLevel = value;
+						await this.plugin.saveSettings();
+					})
+			)
+
         new Setting(containerEl)
             .setName("Link prefix")
             .setDesc("String inserted in front of linked verses, for example '>' for quote. Leave empty for no prefix.")

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -174,7 +174,7 @@ export class SettingsTab extends PluginSettingTab {
                 dropdown.setValue(this.plugin.settings.linkTypePreset)
                 dropdown.onChange(async (value) => {
                     this.plugin.settings.linkTypePreset = value as LinkType;
-                    await this.plugin.saveSettings;
+                    await this.plugin.saveSettings();
                 })
             })
 

--- a/src/utils/convert-link.ts
+++ b/src/utils/convert-link.ts
@@ -156,7 +156,7 @@ function tryConvertToOBSKFileName(bookAndChapter: string) {
 async function createCopyOutput(app: App, tFile: TFile, userChapterInput: string, fileName: string, beginVerse: number, endVerse: number, settings: PluginSettings) {
     const file = app.vault.read(tFile)
     const lines = (await file).split(/\r?\n/)
-	const verseHeadingLevel = settings.verseHeadingLevel.length
+	const verseHeadingLevel = settings.verseHeadingLevel
     const headings = app.metadataCache.getFileCache(tFile).headings.filter(heading => !verseHeadingLevel || heading.level === verseHeadingLevel)
     const beginVerseNoOffset = beginVerse
     const endVerseNoOffset = endVerse

--- a/src/utils/convert-link.ts
+++ b/src/utils/convert-link.ts
@@ -134,7 +134,7 @@ function getVerseText(verseNumber: number, headings: HeadingCache[], lines: stri
             new Notice("Logical error - please create issue on plugin's GitHub with your input and the file you were referencing. Thank you!")
             throw `HeadingLine ${headingLine + 1} is out of range of lines with length ${lines}`
         }
-        return lines[headingLine + 1] 
+        return lines[headingLine + 1] || lines[headingLine + 2]
 }
 
 /**

--- a/src/utils/convert-link.ts
+++ b/src/utils/convert-link.ts
@@ -156,7 +156,8 @@ function tryConvertToOBSKFileName(bookAndChapter: string) {
 async function createCopyOutput(app: App, tFile: TFile, userChapterInput: string, fileName: string, beginVerse: number, endVerse: number, settings: PluginSettings) {
     const file = app.vault.read(tFile)
     const lines = (await file).split(/\r?\n/)
-    const headings = app.metadataCache.getFileCache(tFile).headings;
+	const verseHeadingLevel = settings.verseHeadingLevel.length
+    const headings = app.metadataCache.getFileCache(tFile).headings.filter(heading => !verseHeadingLevel || heading.level === verseHeadingLevel)
     const beginVerseNoOffset = beginVerse
     const endVerseNoOffset = endVerse
     beginVerse += settings.verseOffset


### PR DESCRIPTION
Thanks a lot for your efforts to develop this plugin, I really like it!

Two things didn't work for my markdown bible when trying to "Copy Bible verses". 
With this pull request I'd like to fix these.
 
## 1. Support having headings (of higher level) in between verses

```
###### 1
1st verse text

## Some helpful heading that is not a verse number

###### 2
2nd verse text

###### 3
3rd verse text
```

=>  Support added by new setting to specify which heading level to search for when copying verses.

## 2. Support empty line between verse heading and verse text

Because I format my markdown to have an empty line underneath each heading:

```
###### 1

1st verse text

###### 2

2st verse text
```

If these cases seem to specific to you, feel free to say so or only use part of it :)
