### PR TITLE
Fix broken preview and duplicate click handlers in copy-verse modal

### DIFF
--- a/src/modals/copy-verse-modal.ts
+++ b/src/modals/copy-verse-modal.ts
@@ -6,6 +6,7 @@ import {getTextOfVerses, getTranslationNameFromPath} from "../logic/copy-command
  * Async function for fetching preview
  */
 async function setPreviewText(
+	app: App,
 	previewEl: HTMLTextAreaElement,
 	userInput: string,
 	pluginSettings: PluginSettings,
@@ -14,7 +15,7 @@ async function setPreviewText(
 ) {
 	try {
 		const res = await getTextOfVerses(
-			this.app,
+			app,
 			userInput,
 			pluginSettings,
 			translationPath,
@@ -79,6 +80,7 @@ export default class CopyVerseModal extends Modal {
 
 		const refreshPreview = () => {
 			setPreviewText(
+				this.app,
 				previewEl,
 				this.userInput,
 				this.pluginSettings,
@@ -118,9 +120,6 @@ export default class CopyVerseModal extends Modal {
 					buttons.push(btn);
 					buttonPathMap.set(btn, path);
 					btn.setButtonText(getTranslationNameFromPath(path));
-				});
-
-				buttons.forEach((btn) => {
 					// make sure that only one is selected at a time
 					btn.onClick(() => {
 						buttons.forEach((b) => b.removeCta()); // remove CTA from all buttons
@@ -129,11 +128,11 @@ export default class CopyVerseModal extends Modal {
 						refreshPreview();
 					});
 				});
-
-				// preselect the first button/trnaslation
-				buttons.first().setCta();
-				this.translationPath = buttonPathMap.get(buttons.first());
 			});
+
+			// preselect the first button/translation
+			buttons.first().setCta();
+			this.translationPath = buttonPathMap.get(buttons.first());
 		}
 
 		// add link-only options


### PR DESCRIPTION
## Summary

This PR fixes two minor bugs in the copy-verse modal (`src/modals/copy-verse-modal.ts`):

1. **Fix `this.app` in standalone `setPreviewText` function**: The `setPreviewText` function is a module-level function, not a class method, so `this` does not refer to the Modal instance when called. In esbuild's CJS output (sloppy mode), `this` resolves to `globalThis`, meaning `this.app` is `undefined`. This causes `getTextOfVerses` to throw, which the `try/catch` silently swallows — resulting in the preview textarea always showing empty. The fix passes `app` as an explicit parameter.

2. **Fix duplicate click handlers on translation buttons**: The original code ran `buttons.forEach((btn) => btn.onClick(...))` inside the outer `parsedTranslationPaths.forEach` loop, meaning each button accumulated extra click handlers on every iteration (button 1 got N handlers for N translations). This caused redundant `refreshPreview()` calls. The fix moves the `onClick` registration inside the `addButton` callback so each button gets exactly one handler.

3. **Move preselection outside loop**: The first-button preselection (`buttons.first().setCta()`) was running on every loop iteration. Moved it after the loop where it only needs to run once. Also fixes a typo (`trnaslation` → `translation`).

## ⚠️ Note on Issue #65

These changes do **not** address the wrong verse number reported in #65. As the maintainer identified in the issue comments, that is a `verseOffset` configuration issue — the user's Latin Bible files have a different heading structure than the Portuguese files, causing an off-by-one when `verseOffset` is set to 0 instead of -1.

## Changes
```
 src/modals/copy-verse-modal.ts | 15 +++++++--------
 1 file changed, 7 insertions(+), 8 deletions(-)
```

---
*This PR was created with the assistance of AI. The `this.app` bug was verified by inspecting esbuild's CJS output — the standalone function's `this` resolves to `globalThis`, not the Modal instance.*