### PR TITLE
Implemented population of selected Bible verses for the reference field.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -120,9 +120,16 @@ const DEFAULT_SETTINGS: Partial<PluginSettings> = {
 };
 
 
-function replaceRangeAndMoveCursor(str: string, editor: Editor) {
-	editor.replaceRange(str, editor.getCursor());
-	let offset = editor.posToOffset(editor.getCursor())
+function replaceSelectionOrInsertAtCursor(str: string, editor: Editor) {
+	// Capture the insertion point before the edit: start of the selection if
+	// there is one, otherwise the current cursor position.
+	const insertionPoint = editor.getCursor("from");
+	// Replace the current selection with str (or insert at cursor if nothing
+	// is selected). This deletes any selected text first.
+	editor.replaceSelection(str);
+	// Explicitly move the cursor to the end of the inserted text using offsets
+	// (preserves the original replaceRangeAndMoveCursor behavior).
+	let offset = editor.posToOffset(insertionPoint);
 	offset += str.length;
 	editor.setCursor(editor.offsetToPos(offset));
 }
@@ -134,8 +141,10 @@ export default class BibleLinkerPlugin extends Plugin {
     openCopyModal = () => {
 		const editor = this.app.workspace.activeEditor?.editor
         if (editor) {
+            const prefill = editor.getSelection();
             new CopyVerseModal(this.app, this.settings,
-                (str) => replaceRangeAndMoveCursor(str, editor)
+                (str) => replaceSelectionOrInsertAtCursor(str, editor),
+                prefill
 			).open();
         }
     }
@@ -144,8 +153,10 @@ export default class BibleLinkerPlugin extends Plugin {
     openObsidianLinkModal = () => {
 		const editor = this.app.workspace.activeEditor?.editor
         if (editor) {
+            const prefill = editor.getSelection();
             new LinkVerseModal(this.app, this.settings,
-                (str) => replaceRangeAndMoveCursor(str, editor)
+                (str) => replaceSelectionOrInsertAtCursor(str, editor),
+                prefill
 			).open();
         }
     }

--- a/src/modals/copy-verse-modal.ts
+++ b/src/modals/copy-verse-modal.ts
@@ -66,11 +66,13 @@ export default class CopyVerseModal extends Modal {
 	constructor(
 		app: App,
 		settings: PluginSettings,
-		onSubmit: (result: string) => void
+		onSubmit: (result: string) => void,
+		prefill = ""
 	) {
 		super(app);
 		this.onSubmit = onSubmit;
 		this.pluginSettings = settings;
+		this.userInput = prefill;
 	}
 
 	onOpen() {
@@ -91,14 +93,16 @@ export default class CopyVerseModal extends Modal {
 		contentEl.createEl("h3", { text: "Copy verse by bible reference" });
 
 		// Add Textbox for reference
-		new Setting(contentEl).setName("Insert reference").addText((text) =>
+		new Setting(contentEl).setName("Insert reference").addText((text) => {
 			text
+				.setValue(this.userInput ?? "")
 				.onChange((value) => {
 					this.userInput = value;
 					refreshPreview();
-				})
-				.inputEl.focus()
-		); // Sets focus to input field
+				});
+			text.inputEl.focus();
+			text.inputEl.select();
+		}); // Sets focus to input field
 
 		// Add translation picker
 		if (
@@ -165,6 +169,11 @@ export default class CopyVerseModal extends Modal {
 				this.handleInput();
 			}
 		};
+
+		// If a prefill was provided, render the initial preview
+		if (this.userInput) {
+			refreshPreview();
+		}
 	}
 
 	onClose() {

--- a/src/modals/link-verse-modal.ts
+++ b/src/modals/link-verse-modal.ts
@@ -38,13 +38,15 @@ export default class LinkVerseModal extends Modal {
 	constructor(
 		app: App,
 		settings: PluginSettings,
-		onSubmit: (result: string) => void
+		onSubmit: (result: string) => void,
+		prefill = ""
 	) {
 		super(app);
 		this.onSubmit = onSubmit;
 		this.pluginSettings = settings;
 		this.linkType = this.pluginSettings.linkTypePreset;
 		this.useNewLine = this.pluginSettings.newLinePreset;
+		this.userInput = prefill;
 	}
 
 	onOpen() {
@@ -56,13 +58,15 @@ export default class LinkVerseModal extends Modal {
 		});
 
 		// Add Textbox for reference
-		new Setting(contentEl).setName("Insert reference").addText((text) =>
+		new Setting(contentEl).setName("Insert reference").addText((text) => {
 			text
+				.setValue(this.userInput ?? "")
 				.onChange((value) => {
 					this.userInput = value;
-				})
-				.inputEl.focus()
-		); // Sets focus to input field
+				});
+			text.inputEl.focus();
+			text.inputEl.select();
+		}); // Sets focus to input field
 
 		new Setting(contentEl).setName("Link type").addDropdown((dropdown) => {
 			dropdown.addOption(LinkType.Basic, LinkType.Basic);


### PR DESCRIPTION
I implemented a feature that allows you to select a Bible verse in your note and when you press the keyboard shortcut, the selected text automatically populates the "insert reference" field in the modal. This addresses my most missing feature ;)

You should test this thoroughly, as I'm unsure which other feature it might interfere with.